### PR TITLE
Add a not_gitops_image_repository_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ When you run `bazel run ///helloworld:mynamespace.apply`, it applies this file i
 | ***image_registry***      | `docker.io`    | The registry to push images to.
 | ***image_repository***    | `None`         | The repository to push images to. By default, this is generated from the current package path.
 | ***image_repository_prefix*** | `None`     | Add a prefix to the image_repository. Can be used to upload the images in
+| ***not_gitops_image_repository_prefix*** | `{BUILD_USER}`     | Add a prefix to the image_repository when gitops == False for the .apply|.delete targets
 | ***release_branch_prefix*** | `master`     | A git branch name/prefix. Automatically run GitOps while building this branch. See [GitOps and Deployment](#gitops_and_deployment).
 | ***deployment_branch***   | `None`         | Automatic GitOps output will appear in a branch and PR with this name. See [GitOps and Deployment](#gitops_and_deployment).
 | ***gitops_path***         | `cloud`        | Path within the git repo where gitops files get generated into

--- a/skylib/k8s.bzl
+++ b/skylib/k8s.bzl
@@ -126,6 +126,7 @@ def k8s_deploy(
         objects = [],
         gitops = True,  # make sure to use gitops = False to work with individual namespace. This option will be turned False if namespace is '{BUILD_USER}'
         gitops_path = "cloud",
+        not_gitops_image_repository_prefix = '{BUILD_USER}',  # Sets the .apply|.delete targets to utilize a repository prefix when gitops is False
         deployment_branch = None,
         release_branch_prefix = "master",
         flatten_manifest_directories = False,
@@ -158,7 +159,7 @@ def k8s_deploy(
             images = images,
             image_registry = image_registry,
             image_repository = image_repository,
-            image_repository_prefix = "{BUILD_USER}",
+            image_repository_prefix = not_gitops_image_repository_prefix,
             image_digest_tag = image_digest_tag,
         )
         kustomize(


### PR DESCRIPTION
This allows the image repository prefix to be configured when running in gitops==False.
Defaults to current behavior where the image_repository_prefix will == the `{BUILD_USER}` when pushing the image to the remote repository.